### PR TITLE
Upgrade commonmarker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -175,6 +175,12 @@ gem "pry"
 # A great debugger.
 gem "pry"
 
+# We specify this gem here so that we can get the auto-generated links on headers in the docs
+# https://github.com/bullet-train-co/bullet_train-core/pull/468
+# Once commonmarker 1.x is no longer a pre-release we'll bump the main `bullet_train` dependency
+# and then we can remove this from our Gemfile.
+gem 'commonmarker', '~> 1.0.0.pre10'
+
 # YOUR GEMS
 # You can add any Ruby gems you need below. By keeping them separate from our gems above, you'll avoid the likelihood
 # that you run into a merge conflict in the future.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,7 +217,8 @@ GEM
       sexp_processor
     coderay (1.1.3)
     colorize (1.1.0)
-    commonmarker (0.23.10)
+    commonmarker (1.0.0.pre10-arm64-darwin)
+    commonmarker (1.0.0.pre10-x86_64-linux)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -628,6 +629,7 @@ DEPENDENCIES
   capybara-email
   chronic
   colorize
+  commonmarker (~> 1.0.0.pre10)
   cssbundling-rails
   debug
   devise


### PR DESCRIPTION
This allows us to thet the auto-generated links on headers in the docs.

https://github.com/bullet-train-co/bullet_train-core/pull/468