### PR TITLE
Bullet Train Update: 1.6.34

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -112,7 +112,7 @@ end
 
 # We use a constant here so that we can ensure that all of the bullet_train-*
 # packages are on the same version.
-BULLET_TRAIN_VERSION = "1.6.33"
+BULLET_TRAIN_VERSION = "1.6.34"
 
 # Core packages.
 gem "bullet_train", BULLET_TRAIN_VERSION

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,7 @@ GEM
     bootsnap (1.17.1)
       msgpack (~> 1.2)
     builder (3.2.4)
-    bullet_train (1.6.33)
+    bullet_train (1.6.34)
       awesome_print
       bullet_train-has_uuid
       bullet_train-roles
@@ -160,7 +160,7 @@ GEM
       unicode-emoji
       valid_email
       xxhash
-    bullet_train-api (1.6.33)
+    bullet_train-api (1.6.34)
       bullet_train
       bullet_train-super_scaffolding
       colorizer
@@ -171,61 +171,61 @@ GEM
       pagy_cursor
       rack-cors
       rails (>= 6.0.0)
-    bullet_train-fields (1.6.33)
+    bullet_train-fields (1.6.34)
       chronic
       cloudinary
       phonelib
       rails (>= 6.0.0)
-    bullet_train-has_uuid (1.6.33)
+    bullet_train-has_uuid (1.6.34)
       rails (>= 6.0.0)
-    bullet_train-incoming_webhooks (1.6.33)
+    bullet_train-incoming_webhooks (1.6.34)
       bullet_train
       bullet_train-api
       bullet_train-super_scaffolding
       rails (>= 6.0.0)
-    bullet_train-integrations (1.6.33)
+    bullet_train-integrations (1.6.34)
       rails (>= 6.0.0)
-    bullet_train-integrations-stripe (1.6.33)
+    bullet_train-integrations-stripe (1.6.34)
       omniauth
       omniauth-rails_csrf_protection
       omniauth-stripe-connect
       rails (>= 6.0.0)
       stripe
-    bullet_train-obfuscates_id (1.6.33)
+    bullet_train-obfuscates_id (1.6.34)
       hashids
       rails (>= 6.0.0)
-    bullet_train-outgoing_webhooks (1.6.33)
+    bullet_train-outgoing_webhooks (1.6.34)
       public_suffix
       rails (>= 6.0.0)
-    bullet_train-roles (1.6.33)
+    bullet_train-roles (1.6.34)
       active_hash
       activesupport
       cancancan
     bullet_train-routes (1.0.0)
       rails (>= 6.0.0)
-    bullet_train-scope_questions (1.6.33)
+    bullet_train-scope_questions (1.6.34)
       rails (>= 6.0.0)
-    bullet_train-scope_validator (1.6.33)
+    bullet_train-scope_validator (1.6.34)
       rails
-    bullet_train-sortable (1.6.33)
+    bullet_train-sortable (1.6.34)
       rails (>= 6.0.0)
-    bullet_train-super_load_and_authorize_resource (1.6.33)
+    bullet_train-super_load_and_authorize_resource (1.6.34)
       cancancan
       rails (>= 6.0.0)
-    bullet_train-super_scaffolding (1.6.33)
+    bullet_train-super_scaffolding (1.6.34)
       colorizer
       indefinite_article
       masamune-ast (~> 2.0.2)
       rails (>= 6.0.0)
-    bullet_train-themes (1.6.33)
+    bullet_train-themes (1.6.34)
       bullet_train-fields
       nice_partials (~> 0.9)
       rails (>= 6.0.0)
-    bullet_train-themes-light (1.6.33)
+    bullet_train-themes-light (1.6.34)
       bullet_train-themes-tailwind_css
       masamune-ast (~> 2.0.2)
       rails (>= 6.0.0)
-    bullet_train-themes-tailwind_css (1.6.33)
+    bullet_train-themes-tailwind_css (1.6.34)
       bullet_train-themes
       rails (>= 6.0.0)
     cable_ready (5.0.3)
@@ -712,24 +712,24 @@ DEPENDENCIES
   avo (>= 3.1.7)
   aws-sdk-s3
   bootsnap
-  bullet_train (= 1.6.33)
-  bullet_train-api (= 1.6.33)
-  bullet_train-fields (= 1.6.33)
-  bullet_train-has_uuid (= 1.6.33)
-  bullet_train-incoming_webhooks (= 1.6.33)
-  bullet_train-integrations (= 1.6.33)
-  bullet_train-integrations-stripe (= 1.6.33)
-  bullet_train-obfuscates_id (= 1.6.33)
-  bullet_train-outgoing_webhooks (= 1.6.33)
-  bullet_train-roles (= 1.6.33)
-  bullet_train-scope_questions (= 1.6.33)
-  bullet_train-scope_validator (= 1.6.33)
-  bullet_train-sortable (= 1.6.33)
-  bullet_train-super_load_and_authorize_resource (= 1.6.33)
-  bullet_train-super_scaffolding (= 1.6.33)
-  bullet_train-themes (= 1.6.33)
-  bullet_train-themes-light (= 1.6.33)
-  bullet_train-themes-tailwind_css (= 1.6.33)
+  bullet_train (= 1.6.34)
+  bullet_train-api (= 1.6.34)
+  bullet_train-fields (= 1.6.34)
+  bullet_train-has_uuid (= 1.6.34)
+  bullet_train-incoming_webhooks (= 1.6.34)
+  bullet_train-integrations (= 1.6.34)
+  bullet_train-integrations-stripe (= 1.6.34)
+  bullet_train-obfuscates_id (= 1.6.34)
+  bullet_train-outgoing_webhooks (= 1.6.34)
+  bullet_train-roles (= 1.6.34)
+  bullet_train-scope_questions (= 1.6.34)
+  bullet_train-scope_validator (= 1.6.34)
+  bullet_train-sortable (= 1.6.34)
+  bullet_train-super_load_and_authorize_resource (= 1.6.34)
+  bullet_train-super_scaffolding (= 1.6.34)
+  bullet_train-themes (= 1.6.34)
+  bullet_train-themes-light (= 1.6.34)
+  bullet_train-themes-tailwind_css (= 1.6.34)
   capybara (~> 3.39)
   capybara-email
   capybara-lockstep

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "app",
   "private": true,
   "dependencies": {
-    "@bullet-train/bullet-train": "1.6.33",
-    "@bullet-train/bullet-train-sortable": "1.6.33",
-    "@bullet-train/fields": "1.6.33",
+    "@bullet-train/bullet-train": "1.6.34",
+    "@bullet-train/bullet-train-sortable": "1.6.34",
+    "@bullet-train/fields": "1.6.34",
     "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
     "@fullhuman/postcss-purgecss": "5.0.0",
     "@hotwired/turbo-rails": "^8.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1061,26 +1061,26 @@
     "@babel/helper-validator-identifier" "^7.22.19"
     to-fast-properties "^2.0.0"
 
-"@bullet-train/bullet-train-sortable@1.6.33":
-  version "1.6.33"
-  resolved "https://registry.yarnpkg.com/@bullet-train/bullet-train-sortable/-/bullet-train-sortable-1.6.33.tgz#20759d19b24aa8757356064e512f961cbec4d97c"
-  integrity sha512-8a7ykBHmBR+67kB9j2aDvps4gWnwlUS1AmGXOOROHd/UMpbnB0iDj54X5SYUUVXPlEGF1UxFzaia2MVLRumJMA==
+"@bullet-train/bullet-train-sortable@1.6.34":
+  version "1.6.34"
+  resolved "https://registry.yarnpkg.com/@bullet-train/bullet-train-sortable/-/bullet-train-sortable-1.6.34.tgz#f933e2be57acfc7cf12c8dfc9b68224cc5be5523"
+  integrity sha512-YCaJhWK8zBzICFJ1iED/icWZEI+QI0+oqS0Ok7k83ERs6LR8qBxOBduPhsJdTCbi+aBSfL2g3x6MVIFZszT4gA==
   dependencies:
     "@hotwired/stimulus" "^3.0.1"
     "@rails/request.js" "^0.0.6"
     dragula "^3.7.3"
 
-"@bullet-train/bullet-train@1.6.33":
-  version "1.6.33"
-  resolved "https://registry.yarnpkg.com/@bullet-train/bullet-train/-/bullet-train-1.6.33.tgz#c3b9b5c84ba4cf2b1285fb668c2c0cd6ba46d064"
-  integrity sha512-nBKMINTUg/vVl9Jm+po5zVP2ZJBHWzXNew1yg8k2u1CYrHb5uDRd/T+rQTPHAYJV3yoTwB0KHBiWb47MuRg8ew==
+"@bullet-train/bullet-train@1.6.34":
+  version "1.6.34"
+  resolved "https://registry.yarnpkg.com/@bullet-train/bullet-train/-/bullet-train-1.6.34.tgz#1d86e331128c219b9561aed244287ced6f9d338e"
+  integrity sha512-uI6/F0AByA/tE2RCobVQDYLtCgJzMOlxuyifQidvzNgli7zwwXlEIvU3fA+8nXmBqa0+JegbxKzyXpDokcuviQ==
   dependencies:
     "@hotwired/stimulus" "^3.0.1"
 
-"@bullet-train/fields@1.6.33":
-  version "1.6.33"
-  resolved "https://registry.yarnpkg.com/@bullet-train/fields/-/fields-1.6.33.tgz#1af64d9962fb0f611c0243723c00f35984346e60"
-  integrity sha512-D2/mpeqHSyjlPSMy2rirVr28T7oPrwAeQKRPepjLr3MoujANnCX6Sr4Qu648xX4373gKFjUiwcOjECdDEpaoqA==
+"@bullet-train/fields@1.6.34":
+  version "1.6.34"
+  resolved "https://registry.yarnpkg.com/@bullet-train/fields/-/fields-1.6.34.tgz#f8638ac47c55314bb30c804c63410c282a774c1e"
+  integrity sha512-zgfWhynmH6GRq3vmdPKwwucg4m/6SjDVw8T60R68j+fsVxqCPhrJeuk5YqHtupERcncezr+SN62rlccUvXmlGw==
   dependencies:
     "@hotwired/stimulus" "^3.0.1"
     "@simonwep/pickr" "^1.8.1"


### PR DESCRIPTION
Update of the Bullet Train Starter Repo to version `1.6.34`

**Please note:** You should thorougly review this PR.

🎉 There are no conflicts detected in this PR!

> Auto-generated by `.github/workflows/update-bullet-train.yml`